### PR TITLE
More recent python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9.0]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,18 +31,18 @@ jobs:
       run: |
         flake8 .
     - name: Check formatting with black
-      if: "matrix.python-version == '3.6'"
+      if: "matrix.python-version == '3.8'"
       run: |
         pip install -U black
         black --check .
     - name: Build packages
-      if: "matrix.python-version == '3.6'"
+      if: "matrix.python-version == '3.8'"
       run: |
         pip install -U twine wheel
         python setup.py sdist bdist_wheel
         twine check dist/*
     - name: Upload packages
-      if: "matrix.python-version == '3.6'"
+      if: "matrix.python-version == '3.8'"
       uses: actions/upload-artifact@v2
       with:
         name: gcp-flowlogs-reader-packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = gcp_flowlogs_reader
 version = 0.8.1
 license = Apache
-url = https://github.com/obsrvbl/gcp-flowlogs-reader
+url = https://github.com/obsrvbl-oss/gcp-flowlogs-reader
 description = Reader for Google Cloud VPC Flow Logs
 long_description =
     This project provides a convenient interface for accessing
@@ -15,10 +15,11 @@ classifiers =
     Intended Audience :: Information Technology
     Intended Audience :: System Administrators
     License :: OSI Approved :: Apache Software License
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
 
 [options]
 packages = find:


### PR DESCRIPTION
This PR updates the GitHub actions to drop Python 3.6 and add 3.10 and 3.11.

Also updates a reference to the github org from `obsrvbl` to `obsrvbl-oss`.