### PR TITLE
add breaking test case

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -43,7 +43,7 @@ jobs:
         twine check dist/*
     - name: Upload packages
       if: "matrix.python-version == '3.8'"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: gcp-flowlogs-reader-packages
         path: dist/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         coverage report --show-missing --fail-under=99.0
     - name: Lint with flake8
       run: |
-        flake8 .
+        flake8 gcp_flowlogs_reader tests
     - name: Check formatting with black
       if: "matrix.python-version == '3.8'"
       run: |

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -67,7 +67,6 @@ def safe_tuple_from_dict(cls, attrs):
     return cls(**attr_payload)
 
 
-
 class FlowRecord:
     src_ip: Union[IPv4Address, IPv6Address]
     src_port: int

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -121,7 +121,7 @@ class FlowRecord:
         ]:
             try:
                 value = safe_tuple_from_dict(cls, flow_payload[attr])
-            except (KeyError, TypeError) as e:
+            except (KeyError, TypeError):
                 setattr(self, attr, None)
             else:
                 setattr(self, attr, value)

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -62,6 +62,12 @@ class ResourceLabels(NamedTuple):
     subnetwork_name: str
 
 
+def safe_tuple_from_dict(cls, attrs):
+    attr_payload = {k: attrs[k] for k in cls._fields}
+    return cls(**attr_payload)
+
+
+
 class FlowRecord:
     src_ip: Union[IPv4Address, IPv6Address]
     src_port: int
@@ -115,9 +121,8 @@ class FlowRecord:
             ('dest_location', GeographicDetails),
         ]:
             try:
-                attr_payload = {k: flow_payload[k] for k in cls._fields}
-                value = cls(**attr_payload)
-            except (KeyError, TypeError):
+                value = safe_tuple_from_dict(cls, flow_payload[attr])
+            except (KeyError, TypeError) as e:
                 setattr(self, attr, None)
             else:
                 setattr(self, attr, value)

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -115,7 +115,8 @@ class FlowRecord:
             ('dest_location', GeographicDetails),
         ]:
             try:
-                value = cls(**flow_payload[attr])
+                attr_payload = {k: flow_payload[k] for k in cls._fields}
+                value = cls(**attr_payload)
             except (KeyError, TypeError):
                 setattr(self, attr, None)
             else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gcp_flowlogs_reader
-version = 0.9.0
+version = 1.0.0
 license = Apache
 url = https://github.com/obsrvbl-oss/gcp-flowlogs-reader
 description = Reader for Google Cloud VPC Flow Logs

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gcp_flowlogs_reader
-version = 1.0.0
+version = 2.0.0
 license = Apache
 url = https://github.com/obsrvbl-oss/gcp-flowlogs-reader
 description = Reader for Google Cloud VPC Flow Logs

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ python_requires = >=3.6
 install_requires =
     google-cloud-logging < 2.0
     google-cloud-resource-manager
+    six
 
 [options.packages.find]
 exclude =

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -44,6 +44,7 @@ SAMPLE_PAYLOADS = [
         'dest_vpc': {
             'project_id': 'yoyodyne-102010',
             'subnetwork_name': 'yoyo-vpc-1',
+            'subnetwork_region': 'sunnydale1',
             'vpc_name': 'yoyo-vpc-1',
         },
         'end_time': '2018-04-03T13:47:38.401Z',
@@ -85,6 +86,7 @@ SAMPLE_PAYLOADS = [
         'src_vpc': {
             'project_id': 'yoyodyne-102010',
             'subnetwork_name': 'yoyo-vpc-1',
+            'subnetwork_region': 'sunnydale2',
             'vpc_name': 'yoyo-vpc-1',
         },
         'start_time': '2018-04-03T13:47:32.805417512Z',

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -502,7 +502,7 @@ class ReaderTests(TestCase):
         actual = list(reader)
         expected = [FlowRecord(x) for x in SAMPLE_ENTRIES]
         self.assertEqual(actual, expected)
-        self.assertEqual(reader.bytes_processed, 544)
+        self.assertEqual(reader.bytes_processed, 576)
 
         # Test the client getting called correctly with multiple projects
         expression = (

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -224,10 +224,23 @@ class FlowRecordTests(TestCase):
             ('rtt_msec', 61),
             ('reporter', 'DEST'),
             ('src_instance', None),
-            ('dest_instance', safe_tuple_from_dict(InstanceDetails, SAMPLE_PAYLOADS[0]['dest_instance'])),
+            (
+                'dest_instance',
+                safe_tuple_from_dict(
+                    InstanceDetails, SAMPLE_PAYLOADS[0]['dest_instance']
+                ),
+            ),
             ('src_vpc', None),
-            ('dest_vpc', safe_tuple_from_dict(VpcDetails, SAMPLE_PAYLOADS[0]['dest_vpc'])),
-            ('src_location', safe_tuple_from_dict(GeographicDetails, SAMPLE_PAYLOADS[0]['src_location'])),
+            (
+                'dest_vpc',
+                safe_tuple_from_dict(VpcDetails, SAMPLE_PAYLOADS[0]['dest_vpc']),
+            ),
+            (
+                'src_location',
+                safe_tuple_from_dict(
+                    GeographicDetails, SAMPLE_PAYLOADS[0]['src_location']
+                ),
+            ),
             ('dest_location', None),
         ]:
             with self.subTest(attr=attr):
@@ -249,12 +262,25 @@ class FlowRecordTests(TestCase):
             ('packets_sent', 6),
             ('rtt_msec', None),
             ('reporter', 'SRC'),
-            ('src_instance', safe_tuple_from_dict(InstanceDetails, SAMPLE_PAYLOADS[1]['src_instance'])),
+            (
+                'src_instance',
+                safe_tuple_from_dict(
+                    InstanceDetails, SAMPLE_PAYLOADS[1]['src_instance']
+                ),
+            ),
             ('dest_instance', None),
-            ('src_vpc', safe_tuple_from_dict(VpcDetails, SAMPLE_PAYLOADS[1]['src_vpc'])),
+            (
+                'src_vpc',
+                safe_tuple_from_dict(VpcDetails, SAMPLE_PAYLOADS[1]['src_vpc']),
+            ),
             ('dest_vpc', None),
             ('src_location', None),
-            ('dest_location', safe_tuple_from_dict(GeographicDetails, SAMPLE_PAYLOADS[1]['dest_location'])),
+            (
+                'dest_location',
+                safe_tuple_from_dict(
+                    GeographicDetails, SAMPLE_PAYLOADS[1]['dest_location']
+                ),
+            ),
         ]:
             with self.subTest(attr=attr):
                 actual = getattr(flow_record, attr)
@@ -322,7 +348,9 @@ class FlowRecordTests(TestCase):
             with self.subTest(attr=attr):
                 actual = flow_dict[attr]
                 if isinstance(expected, dict):
-                    expected = {k: v for k, v in expected.items() if k != 'subnetwork_region'}
+                    expected = {
+                        k: v for k, v in expected.items() if k != 'subnetwork_region'
+                    }
                 self.assertEqual(actual, expected)
 
     def test_from_payload(self):


### PR DESCRIPTION
GCP added a new field that does not cooperate with the NamedTuple instantiation, this uses the existing NamedTuples but filters to just the fields it understands.

New fields may be handled in a followup change. Missing fields should be treated the same.