### PR TITLE
Use google-cloud-logging >= 3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gcp_flowlogs_reader
-version = 2.0.0
+version = 3.0.0
 license = Apache
 url = https://github.com/obsrvbl-oss/gcp-flowlogs-reader
 description = Reader for Google Cloud VPC Flow Logs

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    google-cloud-logging < 2.0
+    google-cloud-logging >= 3.0
     google-cloud-resource-manager
     six
 

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -9,8 +9,7 @@ from tempfile import NamedTemporaryFile
 from gcp_flowlogs_reader.gcp_flowlogs_reader import BASE_LOG_NAME
 from google.api_core.exceptions import GoogleAPIError, PermissionDenied, NotFound
 from google.cloud.logging import Client
-from google.cloud.logging.entries import StructEntry
-from google.cloud.logging.resource import Resource
+from google.cloud.logging import StructEntry, Resource
 from google.oauth2.service_account import Credentials
 
 from gcp_flowlogs_reader.aggregation import aggregated_records


### PR DESCRIPTION
**Overview**
This PR adds support for `google-cloud-logging >= 3.0`... This will transitively require `google-api-core>=2.0`. The primary changes are as follows:
- logging_client.list_entries no longer has a `projects` argument... It now accepts a list of resources. Internally if `resources` is not provided, it will default to `[f'projects/{self.project_id}']` which is the project_id associated with the client. We make use of this argument, so behavior should be 1:1 to what we are doing now (for multi and single project cases.)
- [`list_entries`](https://github.com/googleapis/python-logging/blob/main/google/cloud/logging_v2/client.py#L211) now pages for you in both the [http logging_api](https://github.com/googleapis/python-logging/blob/main/google/cloud/logging_v2/_http.py#L70) and the [gapic logging_api](https://github.com/googleapis/python-logging/blob/main/google/cloud/logging_v2/_gapic.py#L49).