### PR TITLE
make reader compatible with `google-cloud-logging` v3 releases

### DIFF
--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -48,7 +48,6 @@ def page_helper(logging_client, wait_time=1.0, **kwargs):
     iterator = logging_client.list_entries(**kwargs)
     while True:
         try:
-            iterator = logging_client.list_entries(**kwargs)
             for page in iterator.pages:
                 kwargs['page_token'] = iterator.next_page_token
                 yield from page

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -31,7 +31,7 @@ BASE_LOG_NAME = 'projects/{}/logs/compute.googleapis.com%2Fvpc_flows'
 def page_helper(logging_client, wait_time=1.0, **kwargs):
     # handle google-cloud-logging >= 3.0
     if gcp_logging_version[0] == '3':
-        # the project arg in google-cloud-logging >= 3.0 was changes to resource_names
+        # the project arg in google-cloud-logging >= 3.0 was changed to resource_names
         if 'projects' in kwargs:
             kwargs['resource_names'] = [
                 f'projects/{project}' for project in kwargs['projects']

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -32,7 +32,7 @@ def page_helper(logging_client, wait_time=1.0, **kwargs):
     # handle google-cloud-logging >= 3.0
     if gcp_logging_version[0] == '3':
         # the project arg in google-cloud-logging >= 3.0 was changes to resource_names
-        if kwargs['projects']:
+        if 'projects' in kwargs:
             kwargs['resource_names'] = [
                 f'projects/{project}' for project in kwargs['projects']
             ]

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -11,8 +11,9 @@ from google.api_core.exceptions import (
 )
 from google.cloud.logging import (
     Client as LoggingClient,
-    __version__ as gcp_logging_version
+    __version__ as gcp_logging_version,
 )
+
 try:
     from google.cloud.logging import StructEntry
 except ImportError:

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -9,8 +9,14 @@ from google.api_core.exceptions import (
     NotFound,
     TooManyRequests,
 )
-from google.cloud.logging import Client as LoggingClient
-from google.cloud.logging.entries import StructEntry
+from google.cloud.logging import (
+    Client as LoggingClient,
+    __version__ as gcp_logging_version
+)
+try:
+    from google.cloud.logging import StructEntry
+except ImportError:
+    from google.cloud.logging.entries import StructEntry
 
 try:
     from google.cloud.resource_manager import Client as ResourceManagerClient
@@ -22,7 +28,23 @@ BASE_LOG_NAME = 'projects/{}/logs/compute.googleapis.com%2Fvpc_flows'
 
 
 def page_helper(logging_client, wait_time=1.0, **kwargs):
+    # handle google-cloud-logging >= 3.0
+    if gcp_logging_version[0] == '3':
+        # the project arg in google-cloud-logging >= 3.0 was changes to resource_names
+        if kwargs['projects']:
+            kwargs['resource_names'] = [
+                f'projects/{project}' for project in kwargs['projects']
+            ]
+            del kwargs['projects']
+        # google-cloud-logging >= 3.0 handles paging internally
+        iterator = logging_client.list_entries(**kwargs)
+        for entry in iterator:
+            yield entry
+        return
+
+    # google-cloud-logging < 3.0 requires us to handle paging
     kwargs['page_token'] = None
+    iterator = logging_client.list_entries(**kwargs)
     while True:
         try:
             iterator = logging_client.list_entries(**kwargs)

--- a/gcp_flowlogs_reader/gcp_flowlogs_reader.py
+++ b/gcp_flowlogs_reader/gcp_flowlogs_reader.py
@@ -45,9 +45,9 @@ def page_helper(logging_client, wait_time=1.0, **kwargs):
 
     # google-cloud-logging < 3.0 requires us to handle paging
     kwargs['page_token'] = None
-    iterator = logging_client.list_entries(**kwargs)
     while True:
         try:
+            iterator = logging_client.list_entries(**kwargs)
             for page in iterator.pages:
                 kwargs['page_token'] = iterator.next_page_token
                 yield from page

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gcp_flowlogs_reader
-version = 2.0.0
+version = 2.1.0
 license = Apache
 url = https://github.com/obsrvbl-oss/gcp-flowlogs-reader
 description = Reader for Google Cloud VPC Flow Logs
@@ -25,7 +25,7 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    google-cloud-logging < 2.0
+    google-cloud-logging < 4.0
     google-cloud-resource-manager
     six
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = gcp_flowlogs_reader
-version = 2.1.0
+version = 3.0.0
 license = Apache
 url = https://github.com/obsrvbl-oss/gcp-flowlogs-reader
 description = Reader for Google Cloud VPC Flow Logs

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -9,8 +9,7 @@ from tempfile import NamedTemporaryFile
 from gcp_flowlogs_reader.gcp_flowlogs_reader import BASE_LOG_NAME
 from google.api_core.exceptions import GoogleAPIError, PermissionDenied, NotFound
 from google.cloud.logging import Client
-from google.cloud.logging.entries import StructEntry
-from google.cloud.logging.resource import Resource
+from google.cloud.logging import StructEntry, Resource
 from google.oauth2.service_account import Credentials
 
 from gcp_flowlogs_reader.aggregation import aggregated_records

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -206,6 +206,18 @@ class MockNotFoundIterator:
 class TestClient(Client):
     _credentials = ''
 
+    def list_entries(
+        self,
+        *,
+        projects=None,
+        filter_=None,
+        order_by=None,
+        max_results=None,
+        page_size=None,
+        page_token=None,
+    ):
+        pass
+
 
 class FlowRecordTests(TestCase):
     def test_init_outbound(self):
@@ -372,6 +384,7 @@ class FlowRecordTests(TestCase):
 
 
 @patch(PREFIX('LoggingClient'), autospec=TestClient)
+@patch(PREFIX('gcp_logging_version'), '1.12.2')
 class ReaderTests(TestCase):
     def test_init_with_client(self, MockLoggingClient):
         logging_client = MagicMock(Client)
@@ -712,10 +725,10 @@ class AggregationTests(TestCase):
         )
 
 
+@patch(PREFIX('gcp_logging_version'), '1.12.2')
 class MainCLITests(TestCase):
     def setUp(self):
-        patch_path = PREFIX('LoggingClient')
-        with patch(patch_path, autospec=True) as MockLoggingClient:
+        with patch(PREFIX('LoggingClient'), autospec=TestClient) as MockLoggingClient:
             MockLoggingClient.return_value.project = 'yoyodyne-102010'
             MockLoggingClient.return_value.list_entries.return_value = MockIterator()
             self.reader = Reader()

--- a/tests/test_gcp_flowlogs_reader.py
+++ b/tests/test_gcp_flowlogs_reader.py
@@ -181,11 +181,6 @@ class MockIterator:
         return ''
 
 
-class MockV3Iterator:
-    def __iter__(self):
-        return iter(SAMPLE_ENTRIES[0])
-
-
 class MockFailedIterator:
     def __init__(self):
         self.pages = self


### PR DESCRIPTION
**Overview**
This PR adds support for `google-cloud-logging >= 3.0`... This will transitively require `google-api-core>=2.0`. The primary changes are as follows:
- logging_client.list_entries no longer has a `projects` argument... It now accepts a list of resources. Internally if `resources` is not provided, it will default to `[f'projects/{self.project_id}']` which is the project_id associated with the client. We make use of this argument, so behavior should be 1:1 to what we are doing now (for multi and single project cases.)
- [`list_entries`](https://github.com/googleapis/python-logging/blob/main/google/cloud/logging_v2/client.py#L211) now pages for you in both the [http logging_api](https://github.com/googleapis/python-logging/blob/main/google/cloud/logging_v2/_http.py#L70) and the [gapic logging_api](https://github.com/googleapis/python-logging/blob/main/google/cloud/logging_v2/_gapic.py#L49).
